### PR TITLE
Shift the id of table_a, which will make table_a.id <> tablea_b.id

### DIFF
--- a/scripts.sql
+++ b/scripts.sql
@@ -33,9 +33,9 @@ DO $$
         SELECT random() * 10 + 1 into random_number;
         
         -- SHIFT THE id OF table_a, WHICH WILL MAKE table_a.id <> tablea_b.id
-		INSERT INTO table_a (field_a, field_b)
-		VALUES ('SHIFT', 'SHIFT');
-		TRUNCATE table_a CASCADE;
+        INSERT INTO table_a (field_a, field_b)
+	        VALUES ('SHIFT', 'SHIFT');
+        TRUNCATE table_a CASCADE;
 
         INSERT INTO table_a (field_a, field_b) VALUES ('TEST', random_number);
         INSERT INTO table_b (field_c, table_a_id) VALUES ('TABLE A ' || random_number, (select max(id) from table_a));

--- a/scripts.sql
+++ b/scripts.sql
@@ -31,6 +31,11 @@ DO $$
         random_number record;
     BEGIN
         SELECT random() * 10 + 1 into random_number;
+        
+        -- SHIFT THE id OF table_a, WHICH WILL MAKE table_a.id <> tablea_b.id
+		INSERT INTO table_a (field_a, field_b)
+		VALUES ('SHIFT', 'SHIFT');
+		TRUNCATE table_a CASCADE;
 
         INSERT INTO table_a (field_a, field_b) VALUES ('TEST', random_number);
         INSERT INTO table_b (field_c, table_a_id) VALUES ('TABLE A ' || random_number, (select max(id) from table_a));


### PR DESCRIPTION
- Guarantee that table_a.id <> tablea_b.id;

The idea is to try to simulate a possible case where the ids are not coincident, but we must still merge them.